### PR TITLE
Youtube brand account

### DIFF
--- a/YouTube.py
+++ b/YouTube.py
@@ -12,7 +12,7 @@ path = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 class YTMusicTransfer:
     def __init__(self):
-        self.api = YTMusic(settings['youtube']['headers'])
+        self.api = YTMusic(settings['youtube']['headers'], settings['youtube']['user_id'])
 
     def create_playlist(self, name, info, privacy="PRIVATE", tracks=None):
         return self.api.create_playlist(name, info, privacy, video_ids=tracks)

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -2,6 +2,7 @@
 
 [youtube]
 headers = headers_json_from_browser
+user_id = 
 
 [spotify]
 client_id = id_from_developer_console


### PR DESCRIPTION
Add the ability to use Google brand accounts when creating playlists in YouTube Music. 

By adding a user_id setting in the youtube section of the settings.ini file and using this id (if one is entered), we can create playlists for brand accounts. If the user_id setting is left blank, then it will create the playlist under the users main Google account.